### PR TITLE
Make instructions more usefully non-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cleanly implemented than a more feature-rich version with no tests, no
 documentation, and a poor design. Therefore, you should feel free
 to make any simplifying assumptions necessary to get a basic version of the
 application up and running; for example, you don't need to treat "thing" and
-"things" as the same word. If you have time and are so incined, feel free
+"things" as the same word. If you have time and are so inclined, feel free
 to elaborate further from there.
 
 Document your design and your decisions (within the code and/or in a readme

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ It should _also_ be possible to get the list in JSON format, like this:
 
 In JSON format, the application should list counts for all the words.
 
-We don't want you to have to spend too much time on this, so feel free
+We know time is limited, and the goal of this exercise is to show us the
+quality of your work. We'd much rather see a simple version of the problem
+cleanly implemented than a more feature-rich version with no tests, no
+documentation, and a more design. Therefore, you should feel free
 to make any simplifying assumptions necessary to get a basic version of the
 application up and running; for example, you don't need to treat "thing" and
-"things" as the same word. If you get something working early, consider
-exploring any ways you can see of improving the output format or making the
-output more meaningful.
+"things" as the same word. If you get something working early, feel free
+to explore from there.
 
 Document your design and your decisions (within the code and/or in a readme
 file) including how to run your program and your tests. Explain any fixes or

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ In JSON format, the application should list counts for all the words.
 We know time is limited, and the goal of this exercise is to show us the
 quality of your work. We'd much rather see a simple version of the problem
 cleanly implemented than a more feature-rich version with no tests, no
-documentation, and a more design. Therefore, you should feel free
+documentation, and a poor design. Therefore, you should feel free
 to make any simplifying assumptions necessary to get a basic version of the
 application up and running; for example, you don't need to treat "thing" and
-"things" as the same word. If you get something working early, feel free
-to explore from there.
+"things" as the same word. If you have time and are so incined, feel free
+to elaborate further from there.
 
 Document your design and your decisions (within the code and/or in a readme
 file) including how to run your program and your tests. Explain any fixes or

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ It should _also_ be possible to get the list in JSON format, like this:
 In JSON format, the application should list counts for all the words.
 
 We know time is limited, and the goal of this exercise is to show us the
-quality of your work. We'd much rather see a simple version of the problem
-cleanly implemented than a more feature-rich version with no tests, no
-documentation, and a poor design. Therefore, you should feel free
-to make any simplifying assumptions necessary to get a basic version of the
-application up and running; for example, you don't need to treat "thing" and
-"things" as the same word. If you have time and are so inclined, feel free
-to elaborate further from there.
+quality of your work. We'd much rather see a simple version of your
+solution cleanly implemented than a more feature-rich version with no
+tests, no documentation, and a poor design. Therefore, you should feel
+free to make any simplifying assumptions necessary to get a basic version
+of the application up and running; for example, you don't need to treat
+"thing" and "things" as the same word. If you have time and are so
+inclined, feel free to elaborate further from there.
 
 Document your design and your decisions (within the code and/or in a readme
 file) including how to run your program and your tests. Explain any fixes or

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It should _also_ be possible to get the list in JSON format, like this:
 
 In JSON format, the application should list counts for all the words.
 
-We don't want you to spend more than two or three hours on this, so feel free
+We don't want you to have to spend too much time on this, so feel free
 to make any simplifying assumptions necessary to get a basic version of the
 application up and running; for example, you don't need to treat "thing" and
 "things" as the same word. If you get something working early, consider


### PR DESCRIPTION
Setting a definite (and pretty tight) time limit sends the wrong
message, especially since we haven't done much measurement of how long
this actually tends to take people. Instead, let's just express that we
don't want it to be a burden, but let people judge for themselves
exactly how many hours they want or need to spend on it.